### PR TITLE
Memoize event components

### DIFF
--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -11,6 +11,7 @@ import {
   Mail,
   Terminal
 } from 'lucide-react'
+import { memo, useMemo } from 'react'
 import type { Event } from '../types/events'
 
 interface EventCardProps {
@@ -19,7 +20,7 @@ interface EventCardProps {
 }
 
 const EventCard = ({ event, onClick }: EventCardProps) => {
-  const getEventIcon = () => {
+  const eventIcon = useMemo(() => {
     switch (event.type) {
       case 'message_received':
         return <MessageCircle className="w-5 h-5 text-blue-500" />
@@ -40,9 +41,9 @@ const EventCard = ({ event, onClick }: EventCardProps) => {
       default:
         return <Clock className="w-5 h-5 text-gray-500" />
     }
-  }
+  }, [event.type])
 
-  const getEventColor = () => {
+  const eventColor = useMemo(() => {
     switch (event.type) {
       case 'message_received':
         return 'border-l-blue-500 bg-blue-50'
@@ -63,26 +64,26 @@ const EventCard = ({ event, onClick }: EventCardProps) => {
       default:
         return 'border-l-gray-500 bg-gray-50'
     }
-  }
+  }, [event.type])
 
-  const formatTime = (timestamp: string) => {
-    const date = new Date(timestamp)
+  const formattedTime = useMemo(() => {
+    const date = new Date(event.timestamp)
     return new Intl.DateTimeFormat('en-US', {
       hour: '2-digit',
       minute: '2-digit',
       month: 'short',
       day: 'numeric'
     }).format(date)
-  }
+  }, [event.timestamp])
 
   return (
     <div
-      className={`border-l-4 ${getEventColor()} rounded-r-xl p-6 shadow-sm hover:shadow-md transition-all duration-200 border border-gray-100 cursor-pointer hover:scale-[1.01]`}
+      className={`border-l-4 ${eventColor} rounded-r-xl p-6 shadow-sm hover:shadow-md transition-all duration-200 border border-gray-100 cursor-pointer hover:scale-[1.01]`}
       onClick={onClick}
     >
       <div className="flex items-start justify-between">
         <div className="flex items-start space-x-4 flex-1">
-          <div className="flex-shrink-0 mt-1">{getEventIcon()}</div>
+          <div className="flex-shrink-0 mt-1">{eventIcon}</div>
           <div className="flex-1 min-w-0">
             <h3 className="text-lg font-semibold text-gray-900 mb-1">
               {event.title}
@@ -143,11 +144,11 @@ const EventCard = ({ event, onClick }: EventCardProps) => {
         </div>
         <div className="flex items-center space-x-1 text-sm text-gray-400 ml-4">
           <Clock className="w-4 h-4" />
-          <span>{formatTime(event.timestamp)}</span>
+          <span>{formattedTime}</span>
         </div>
       </div>
     </div>
   )
 }
 
-export default EventCard
+export default memo(EventCard)

--- a/src/components/EventFilter.tsx
+++ b/src/components/EventFilter.tsx
@@ -1,4 +1,5 @@
 import { Filter, X } from 'lucide-react'
+import { memo } from 'react'
 import type { EventType } from '../types/events'
 
 interface EventFilterProps {
@@ -7,54 +8,54 @@ interface EventFilterProps {
   onClearAll: () => void
 }
 
+const EVENT_TYPES: { type: EventType; label: string; color: string }[] = [
+  {
+    type: 'message_received',
+    label: 'Messages',
+    color: 'bg-blue-100 text-blue-800 border-blue-200'
+  },
+  {
+    type: 'thread_started',
+    label: 'New Threads',
+    color: 'bg-green-100 text-green-800 border-green-200'
+  },
+  {
+    type: 'file_altered',
+    label: 'File Changes',
+    color: 'bg-amber-100 text-amber-800 border-amber-200'
+  },
+  {
+    type: 'file_deleted',
+    label: 'File Deletions',
+    color: 'bg-red-100 text-red-800 border-red-200'
+  },
+  {
+    type: 'app_installed',
+    label: 'App Installs',
+    color: 'bg-purple-100 text-purple-800 border-purple-200'
+  },
+  {
+    type: 'contact_request',
+    label: 'Contact Requests',
+    color: 'bg-teal-100 text-teal-800 border-teal-200'
+  },
+  {
+    type: 'email_received',
+    label: 'Emails',
+    color: 'bg-indigo-100 text-indigo-800 border-indigo-200'
+  },
+  {
+    type: 'cron_executed',
+    label: 'Cron Jobs',
+    color: 'bg-gray-100 text-gray-800 border-gray-200'
+  }
+]
+
 const EventFilter = ({
   selectedTypes,
   onTypeToggle,
   onClearAll
 }: EventFilterProps) => {
-  const eventTypes: { type: EventType; label: string; color: string }[] = [
-    {
-      type: 'message_received',
-      label: 'Messages',
-      color: 'bg-blue-100 text-blue-800 border-blue-200'
-    },
-    {
-      type: 'thread_started',
-      label: 'New Threads',
-      color: 'bg-green-100 text-green-800 border-green-200'
-    },
-    {
-      type: 'file_altered',
-      label: 'File Changes',
-      color: 'bg-amber-100 text-amber-800 border-amber-200'
-    },
-    {
-      type: 'file_deleted',
-      label: 'File Deletions',
-      color: 'bg-red-100 text-red-800 border-red-200'
-    },
-    {
-      type: 'app_installed',
-      label: 'App Installs',
-      color: 'bg-purple-100 text-purple-800 border-purple-200'
-    },
-    {
-      type: 'contact_request',
-      label: 'Contact Requests',
-      color: 'bg-teal-100 text-teal-800 border-teal-200'
-    },
-    {
-      type: 'email_received',
-      label: 'Emails',
-      color: 'bg-indigo-100 text-indigo-800 border-indigo-200'
-    },
-    {
-      type: 'cron_executed',
-      label: 'Cron Jobs',
-      color: 'bg-gray-100 text-gray-800 border-gray-200'
-    }
-  ]
-
   return (
     <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
       <div className="flex items-center justify-between mb-4">
@@ -74,7 +75,7 @@ const EventFilter = ({
       </div>
 
       <div className="flex flex-wrap gap-2">
-        {eventTypes.map(({ type, label, color }) => {
+        {EVENT_TYPES.map(({ type, label, color }) => {
           const isSelected = selectedTypes.includes(type)
           return (
             <button
@@ -94,11 +95,11 @@ const EventFilter = ({
 
       {selectedTypes.length > 0 && (
         <div className="mt-4 text-sm text-gray-500">
-          Showing {selectedTypes.length} of {eventTypes.length} event types
+          Showing {selectedTypes.length} of {EVENT_TYPES.length} event types
         </div>
       )}
     </div>
   )
 }
 
-export default EventFilter
+export default memo(EventFilter)

--- a/src/components/EventModal.tsx
+++ b/src/components/EventModal.tsx
@@ -14,7 +14,7 @@ import {
   Hash,
   Calendar
 } from 'lucide-react'
-import { useEffect } from 'react'
+import { useEffect, memo, useMemo } from 'react'
 import { createPortal } from 'react-dom'
 import type { Event } from '../types/events'
 
@@ -33,9 +33,8 @@ const EventModal = ({ event, onClose }: EventModalProps) => {
     }
   }, [event])
 
-  if (!event) return null
-
-  const getEventIcon = () => {
+  const eventIcon = useMemo(() => {
+    if (!event) return null
     switch (event.type) {
       case 'message_received':
         return <MessageCircle className="w-8 h-8 text-blue-500" />
@@ -54,9 +53,10 @@ const EventModal = ({ event, onClose }: EventModalProps) => {
       default:
         return <Clock className="w-8 h-8 text-gray-500" />
     }
-  }
+  }, [event])
 
-  const getEventTypeLabel = () => {
+  const eventTypeLabel = useMemo(() => {
+    if (!event) return ''
     switch (event.type) {
       case 'message_received':
         return 'Message Received'
@@ -75,10 +75,11 @@ const EventModal = ({ event, onClose }: EventModalProps) => {
       default:
         return 'Unknown Event'
     }
-  }
+  }, [event])
 
-  const formatTimestamp = (timestamp: string) => {
-    const date = new Date(timestamp)
+  const formattedTimestamp = useMemo(() => {
+    if (!event) return ''
+    const date = new Date(event.timestamp)
     return new Intl.DateTimeFormat('en-US', {
       weekday: 'long',
       year: 'numeric',
@@ -89,7 +90,9 @@ const EventModal = ({ event, onClose }: EventModalProps) => {
       second: '2-digit',
       timeZoneName: 'short'
     }).format(date)
-  }
+  }, [event])
+
+  if (!event) return null
 
   const handleBackdropClick = (e: React.MouseEvent) => {
     if (e.target === e.currentTarget) {
@@ -106,10 +109,10 @@ const EventModal = ({ event, onClose }: EventModalProps) => {
         {/* Header */}
         <div className="flex items-start justify-between p-6 border-b border-gray-200">
           <div className="flex items-start space-x-4">
-            <div className="flex-shrink-0 mt-1">{getEventIcon()}</div>
+            <div className="flex-shrink-0 mt-1">{eventIcon}</div>
             <div>
               <div className="text-sm font-medium text-gray-500 mb-1">
-                {getEventTypeLabel()}
+                {eventTypeLabel}
               </div>
               <h2 className="text-2xl font-bold text-gray-900 leading-tight">
                 {event.title}
@@ -141,7 +144,7 @@ const EventModal = ({ event, onClose }: EventModalProps) => {
             </h3>
             <div className="flex items-center space-x-2 text-gray-600">
               <Calendar className="w-5 h-5" />
-              <span>{formatTimestamp(event.timestamp)}</span>
+              <span>{formattedTimestamp}</span>
             </div>
           </div>
 
@@ -286,4 +289,4 @@ const EventModal = ({ event, onClose }: EventModalProps) => {
   return createPortal(modal, document.body)
 }
 
-export default EventModal
+export default memo(EventModal)


### PR DESCRIPTION
## Summary
- memoize `EventCard` and expensive event filter helpers
- optimize modal to avoid unnecessary re-renders

## Testing
- `npm run ok`

------
https://chatgpt.com/codex/tasks/task_e_6850ee06ea10832bbef351e516ce3125